### PR TITLE
Update bouncycastle to jdk18on and remove use of deprecated apis

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <java.version>11</java.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <bouncycastle.version>1.70</bouncycastle.version>
+        <bouncycastle.version>1.77</bouncycastle.version>
         <httpclient.version>4.5.13</httpclient.version>
         <testng.version>7.7.1</testng.version>
         <mockito-core.version>4.11.0</mockito-core.version>
@@ -80,7 +80,7 @@
         <!-- BouncyCastle -->
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk15on</artifactId>
+            <artifactId>bcpkix-jdk18on</artifactId>
             <version>${bouncycastle.version}</version>
         </dependency>
 

--- a/src/main/java/network/oxalis/pkix/ocsp/AbstractOcspClient.java
+++ b/src/main/java/network/oxalis/pkix/ocsp/AbstractOcspClient.java
@@ -5,12 +5,17 @@ import network.oxalis.pkix.ocsp.api.OcspFetcherResponse;
 import network.oxalis.pkix.ocsp.builder.Properties;
 import network.oxalis.pkix.ocsp.builder.Property;
 import network.oxalis.pkix.ocsp.fetcher.UrlOcspFetcher;
+import org.bouncycastle.asn1.ASN1IA5String;
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.ASN1Sequence;
 import org.bouncycastle.asn1.ASN1OctetString;
 import org.bouncycastle.asn1.ASN1TaggedObject;
+import org.bouncycastle.asn1.x509.AccessDescription;
+import org.bouncycastle.asn1.x509.AuthorityInformationAccess;
 import org.bouncycastle.asn1.x509.Extension;
 import org.bouncycastle.asn1.x509.GeneralName;
 import org.bouncycastle.asn1.x509.X509ObjectIdentifiers;
+import org.bouncycastle.cert.jcajce.JcaX509ExtensionUtils;
 import org.bouncycastle.x509.extension.X509ExtensionUtil;
 
 import java.io.IOException;
@@ -79,17 +84,20 @@ class AbstractOcspClient {
         }
 
         try {
-            ASN1Sequence asn1Seq = (ASN1Sequence) X509ExtensionUtil.fromExtensionValue(extensionValue);
-            Enumeration<?> objects = asn1Seq.getObjects();
+            
+            AuthorityInformationAccess authInfo = AuthorityInformationAccess.getInstance(
+                JcaX509ExtensionUtils.parseExtensionValue(extensionValue)
+            );
 
-            while (objects.hasMoreElements()) {
-                ASN1Sequence obj = (ASN1Sequence) objects.nextElement();
-                if (obj.getObjectAt(0).equals(X509ObjectIdentifiers.id_ad_ocsp)) {
-                    ASN1TaggedObject  location = (ASN1TaggedObject ) obj.getObjectAt(1);
-                    if (location.getTagNo() == GeneralName.uniformResourceIdentifier) {
-                        ASN1OctetString  uri = (ASN1OctetString ) location.getObject();
-                        return URI.create(new String(uri.getOctets()));
-                    }
+            for (AccessDescription accessDescription : authInfo.getAccessDescriptions()) {
+                final ASN1ObjectIdentifier accessMethod = accessDescription.getAccessMethod();
+                final GeneralName accessLocation = accessDescription.getAccessLocation();
+                if (
+                    X509ObjectIdentifiers.id_ad_ocsp.equals(accessMethod)
+                        && GeneralName.uniformResourceIdentifier == accessLocation.getTagNo()
+                ) {
+                    ASN1IA5String uri = ASN1IA5String.getInstance(accessLocation.getName());
+                    return URI.create(new String(uri.getOctets()));
                 }
             }
         } catch (Exception e) {


### PR DESCRIPTION
The jdk15 build of bouncycastle has vulnerabilities and is no longer maintained. I upgrade to jdk18on and fix errors because of removal of deprecated methods with regards to fetching url from a certificate. I opted to use the new way to get the location of ocsp instead of the getBaseObject-solution I see others have done. This way we hopefully get a more stable code than if we use the getBaseObject-method which has this comment in the source:
> Needed for open types, until we have better type-guided parsing support.